### PR TITLE
Assign unique MAC addresses per slot

### DIFF
--- a/net_config.py
+++ b/net_config.py
@@ -29,4 +29,16 @@ DSU_motor_request = 0x100002
 DSU_motor_response= 0x100002
 
 PROTOCOL_VERSION = 1001
-MAC_ADDRESS = b'\xAA\xBB\xCC\xDD\xEE\xFF'
+
+# Unique MAC addresses per controller slot
+slot1_mac_address = b'\xAA\xBB\xCC\xDD\xEE\x01'
+slot2_mac_address = b'\xAA\xBB\xCC\xDD\xEE\x02'
+slot3_mac_address = b'\xAA\xBB\xCC\xDD\xEE\x03'
+slot4_mac_address = b'\xAA\xBB\xCC\xDD\xEE\x04'
+
+slot_mac_addresses = [
+    slot1_mac_address,
+    slot2_mac_address,
+    slot3_mac_address,
+    slot4_mac_address,
+]

--- a/server.py
+++ b/server.py
@@ -27,7 +27,8 @@ def build_header(msg_type, payload):
     return header + msg
 
 def send_port_info(addr, slot):
-    payload = struct.pack('<4B6s2B', slot, 2, 2, 2, MAC_ADDRESS, 5, 1)
+    mac_address = slot_mac_addresses[slot]
+    payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, 5, 1)
     packet = build_header(DSU_port_info, payload)
     sock.sendto(packet, addr)
     print(f"Sent port info for slot {slot} to {addr}")
@@ -85,7 +86,8 @@ def send_input(addr, slot, buttons1=button_mask_1(), buttons2=button_mask_2(), h
     touch1 = touchpad_input1 or touchpad_input()
     touch2 = touchpad_input2 or touchpad_input()
 
-    payload = struct.pack('<4B6s2BI', slot, 2, 2, 2, MAC_ADDRESS, 5, 1, timestamp_ms)
+    mac_address = slot_mac_addresses[slot]
+    payload = struct.pack('<4B6s2BI', slot, 2, 2, 2, mac_address, 5, 1, timestamp_ms)
     payload += struct.pack('<22B2H2B2HQ6f',
         buttons1, buttons2,
         int(home), int(touch_button),


### PR DESCRIPTION
## Summary
- provide a unique MAC address per controller slot in `net_config.py`
- send the MAC address based on the slot when advertising port info or sending input

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6846c61930f88329aaedecb4173d9bb5