### PR TITLE
Implement DSU port info packet sending

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,6 +30,9 @@ def build_header(msg_type, payload):
 def send_port_info(addr, slot):
     mac_address = slot_mac_addresses[slot]
     payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, 5, 1)
+    packet = build_header(DSU_port_info, payload)
+    sock.sendto(packet, addr)
+    print(f"Sent port info for slot {slot} to {addr}")
 
 def handle_version_request(addr):
     payload = struct.pack('<I H', DSU_version_response, PROTOCOL_VERSION)


### PR DESCRIPTION
## Summary
- send DSU_port_info messages from `send_port_info`
- add debug output for sent port info

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68470b62a3ec8329858ba2258c8d11ea