### PR TITLE
Add slot parameter to controller threads

### DIFF
--- a/inputs.py
+++ b/inputs.py
@@ -6,23 +6,31 @@ press_duration = 3
 cycle_duration = 60
 frame_delay = 1 / 60.0
 
-def pulse_inputs(frame, controller_states, press_duration=press_duration, cycle_duration=cycle_duration):
-    for slot in controller_states:
-        if frame % cycle_duration < press_duration:
-            controller_states[slot].buttons2 = button_mask_2(
-                circle=(slot == 0),
-                cross=(slot == 1),
-                square=(slot == 2),
-                triangle=(slot == 3)
-            )
-        else:
-            controller_states[slot].buttons2 = button_mask_2()
+def pulse_inputs(frame, controller_states, slot,
+                 press_duration=press_duration,
+                 cycle_duration=cycle_duration):
+    """Update the state for a single controller slot.
+
+    The controller_states mapping is still provided so implementations can
+    optionally interact with other slots if desired, but the default behavior
+    only touches the specified *slot*.
+    """
+
+    if frame % cycle_duration < press_duration:
+        controller_states[slot].buttons2 = button_mask_2(
+            circle=(slot == 0),
+            cross=(slot == 1),
+            square=(slot == 2),
+            triangle=(slot == 3)
+        )
+    else:
+        controller_states[slot].buttons2 = button_mask_2()
 
 
-def controller_loop(stop_event, controller_states):
-    """Periodically update controller_states for all slots."""
+def controller_loop(stop_event, controller_states, slot):
+    """Periodically update the state for a single controller slot."""
     frame = 0
     while not stop_event.is_set():
-        pulse_inputs(frame, controller_states)
+        pulse_inputs(frame, controller_states, slot)
         frame += 1
         time.sleep(frame_delay)

--- a/server.py
+++ b/server.py
@@ -155,12 +155,15 @@ if __name__ == "__main__":
 
     stop_event = threading.Event()
 
-    controller_thread = threading.Thread(
-        target=controller_loop,
-        args=(stop_event, controller_states),
-        daemon=True,
-    )
-    controller_thread.start()
+    controller_threads = []
+    for slot in controller_states:
+        thread = threading.Thread(
+            target=controller_loop,
+            args=(stop_event, controller_states, slot),
+            daemon=True,
+        )
+        thread.start()
+        controller_threads.append(thread)
 
     next_frame = time.time()
 
@@ -234,5 +237,6 @@ if __name__ == "__main__":
         print("Server shutting down.")
     finally:
         stop_event.set()
-        controller_thread.join()
+        for thread in controller_threads:
+            thread.join()
         sock.close()


### PR DESCRIPTION
## Summary
- modify `pulse_inputs` and `controller_loop` to work per slot
- launch one controller thread per slot in `server.py`
- join all controller threads during shutdown

## Testing
- `python -m py_compile inputs.py masks.py net_config.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_6847dd8dba108329b6a6760a6ee5a6ee