### PR TITLE
Support requested port list for DSU_list_ports

### DIFF
--- a/net_config.py
+++ b/net_config.py
@@ -12,11 +12,10 @@ UDP_IP = "0.0.0.0"
 UDP_port = 26760
 DSU_timeout = 5.0
 
+# Server state tracking
 server_id = random.randint(0, 0xFFFFFFFF)
 # {addr: {'last_seen': float, 'slots': set()}}
 active_clients = {}
-# Tracks which port info has been announced per client
-client_port_info = {}
 # Set of all slots the server has advertised
 known_slots = {0}
 


### PR DESCRIPTION
## Summary
- parse requested slots in `handle_list_ports`
- respond for each requested slot using `send_port_info` or new `send_port_disconnect`
- stop tracking sent port info per client

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684829e83630832992a76764d214af6b