### PR TITLE
Refine input request logging

### DIFF
--- a/net_config.py
+++ b/net_config.py
@@ -11,6 +11,8 @@ server_id = random.randint(0, 0xFFFFFFFF)
 active_clients = {}
 # Set of all slots the server has advertised
 known_slots = {0}
+# Slots we have already logged input requests for
+logged_pad_requests = set()
 
 # DSU Message Types
 DSU_version_request  = 0x100000

--- a/server.py
+++ b/server.py
@@ -69,7 +69,9 @@ def handle_pad_data_request(addr, data):
     info['last_seen'] = time.time()
     info['slots'].add(slot)
     known_slots.add(slot)
-    print(f"Registered input request from {addr} for slot {slot}")
+    if slot not in logged_pad_requests:
+        print(f"Registered input request from {addr} for slot {slot}")
+        logged_pad_requests.add(slot)
 
 def handle_motor_request(addr, data):
     """Respond with the number of rumble motors for a controller slot."""


### PR DESCRIPTION
## Summary
- track which controller slots were already logged
- avoid spamming logs on repeated button requests

## Testing
- `python -m py_compile net_config.py server.py inputs.py masks.py`

------
https://chatgpt.com/codex/tasks/task_e_68483ac9c6988329b32f0921986c40bb