### PR TITLE
Refine input request logging

### DIFF
--- a/net_config.py
+++ b/net_config.py
@@ -9,8 +9,12 @@ DSU_timeout = 5.0
 server_id = random.randint(0, 0xFFFFFFFF)
 # {addr: {'last_seen': float, 'slots': set()}}
 active_clients = {}
-# Set of all slots the server has advertised
+# Slots the server has already advertised
 known_slots = {0}
+# Slots we have already logged input requests for
+logged_pad_requests = set()
+# Track last button state per slot so we only log changes
+last_button_states = {}
 
 # DSU Message Types
 DSU_version_request  = 0x100000

--- a/server.py
+++ b/server.py
@@ -69,7 +69,9 @@ def handle_pad_data_request(addr, data):
     info['last_seen'] = time.time()
     info['slots'].add(slot)
     known_slots.add(slot)
-    print(f"Registered input request from {addr} for slot {slot}")
+    if slot not in logged_pad_requests:
+        print(f"Registered input request from {addr} for slot {slot}")
+        logged_pad_requests.add(slot)
 
 def handle_motor_request(addr, data):
     """Respond with the number of rumble motors for a controller slot."""
@@ -149,7 +151,15 @@ def send_input(addr, slot, connected=True, packet_num=0,
     payload += struct.pack('<6f', *accelerometer, *gyroscope)
     packet = build_header(DSU_button_response, payload)
     sock.sendto(packet, addr)
-    print(f"Sent input to {addr} slot {slot}")
+
+    prev_state = last_button_states.get(slot)
+    current_state = (buttons1, buttons2)
+    if prev_state != current_state:
+        print(
+            f"Sent input to {addr} slot {slot}: "
+            f"buttons1=0x{buttons1:02X} buttons2=0x{buttons2:02X}"
+        )
+        last_button_states[slot] = current_state
 
 if __name__ == "__main__":
     controller_states = {slot: ControllerState() for slot in range(4)}


### PR DESCRIPTION
## Summary
- track which controller slots were already logged
- avoid spamming logs on repeated button requests
- only print sent inputs when the button state changes

## Testing
- `python -m py_compile net_config.py server.py inputs.py masks.py`


------
https://chatgpt.com/codex/tasks/task_e_68483ac9c6988329b32f0921986c40bb