### PR TITLE
Allow custom input scripts

### DIFF
--- a/circle_loop.py
+++ b/circle_loop.py
@@ -1,0 +1,9 @@
+import time
+from inputs import frame_delay, pulse_button
+
+def controller_loop(stop_event, controller_states, slot):
+    frame = 0
+    while not stop_event.is_set():
+        pulse_button(frame, controller_states, slot, circle=True)
+        frame += 1
+        time.sleep(frame_delay)

--- a/cross_loop.py
+++ b/cross_loop.py
@@ -1,0 +1,9 @@
+import time
+from inputs import frame_delay, pulse_button
+
+def controller_loop(stop_event, controller_states, slot):
+    frame = 0
+    while not stop_event.is_set():
+        pulse_button(frame, controller_states, slot, cross=True)
+        frame += 1
+        time.sleep(frame_delay)

--- a/square_loop.py
+++ b/square_loop.py
@@ -1,0 +1,9 @@
+import time
+from inputs import frame_delay, pulse_button
+
+def controller_loop(stop_event, controller_states, slot):
+    frame = 0
+    while not stop_event.is_set():
+        pulse_button(frame, controller_states, slot, square=True)
+        frame += 1
+        time.sleep(frame_delay)

--- a/triangle_loop.py
+++ b/triangle_loop.py
@@ -1,0 +1,9 @@
+import time
+from inputs import frame_delay, pulse_button
+
+def controller_loop(stop_event, controller_states, slot):
+    frame = 0
+    while not stop_event.is_set():
+        pulse_button(frame, controller_states, slot, triangle=True)
+        frame += 1
+        time.sleep(frame_delay)


### PR DESCRIPTION
## Summary
- move controller loops into individual scripts
- update `inputs.py` to only contain helpers
- load per-slot scripts in `server.py`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684a51bde19c8329af23aff2cf8d7e9d