### PR TITLE
Add rebroadcast via server module

### DIFF
--- a/libraries/masks.py
+++ b/libraries/masks.py
@@ -1,6 +1,24 @@
 from typing import Optional, Tuple
 from dataclasses import dataclass
 
+# Mapping tables for battery levels and connection type values
+BATTERY_STATES = {
+    0x00: "Not applicable",
+    0x01: "Dying",
+    0x02: "Low",
+    0x03: "Medium",
+    0x04: "High",
+    0x05: "Full (or almost)",
+    0xEE: "Charging",
+    0xEF: "Charged",
+}
+
+CONNECTION_TYPES = {
+    0: "N/A",
+    1: "USB",
+    2: "Bluetooth",
+}
+
 def button_mask_1(share=False, l3=False, r3=False, options=False, up=False, right=False, down=False, left=False):
     return (
         (0x01 if share else 0) |

--- a/libraries/masks.py
+++ b/libraries/masks.py
@@ -62,6 +62,9 @@ class ControllerState:
     accelerometer: Tuple[float, float, float] = (0.0, 0.0, 0.0)
     gyroscope: Tuple[float, float, float] = (0.0, 0.0, 0.0)
 
+    # Additional metadata from the originating server
+    battery: int = 5
+
     # Rumble motor intensities and last update timestamps
     motors: Tuple[int, int] = (0, 0)
     motor_timestamps: Tuple[float, float] = (0.0, 0.0)

--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -29,10 +29,11 @@ def build_header(msg_type: int, payload: bytes) -> bytes:
 
 def send_port_info(addr, slot):
     mac_address = slot_mac_addresses[slot]
-    if not controller_states[slot].connected:
+    state = controller_states[slot]
+    if not state.connected:
         payload = b"\x00" * 12
     else:
-        payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, 5, 1)
+        payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, state.battery, 1)
     packet = build_header(DSU_port_info, payload)
     sock.sendto(packet, addr)
     print(f"Sent port info for slot {slot} to {addr}")
@@ -134,6 +135,7 @@ def send_input(
     motion_timestamp=0,
     accelerometer=(0.0, 0.0, 0.0),
     gyroscope=(0.0, 0.0, 0.0),
+    battery=5,
 ):
     if slot not in known_slots:
         known_slots.add(slot)
@@ -151,7 +153,7 @@ def send_input(
     touch2 = touchpad_input2 or touchpad_input()
 
     mac_address = slot_mac_addresses[slot]
-    payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, 5, int(connected))
+    payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, battery, int(connected))
     payload += struct.pack('<I', counter)
     payload += struct.pack(
         '<BBBBBBBBBBBBBBBBBBBB',

--- a/viewer.py
+++ b/viewer.py
@@ -7,23 +7,7 @@ from tkinter import Tk, Label
 from tkinter import ttk
 from tkinter import Menu, simpledialog
 
-# Mapping tables for battery state and connection type values
-BATTERY_STATES = {
-    0x00: "Not applicable",
-    0x01: "Dying",
-    0x02: "Low",
-    0x03: "Medium",
-    0x04: "High",
-    0x05: "Full (or almost)",
-    0xEE: "Charging",
-    0xEF: "Charged",
-}
-
-CONNECTION_TYPES = {
-    0: "N/A",
-    1: "USB",
-    2: "Bluetooth",
-}
+from libraries.masks import BATTERY_STATES, CONNECTION_TYPES
 
 from libraries.net_config import (
     UDP_port,


### PR DESCRIPTION
## Summary
- expose `start_server` helper in server.py so it can run in a thread
- store battery level in `ControllerState`
- send battery info in DSU packets
- update viewer to launch a rebroadcast server using `start_server`

## Testing
- `python -m py_compile viewer.py server.py libraries/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684e47ed65d88329ae0ce85551c6db92