### PR TITLE
Fix rebroadcast stop check

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -329,9 +329,10 @@ class ViewerUI:
         )
         if port is None:
             return
-        if hasattr(self, "rebroadcast_stop"):
+        if self.rebroadcast_stop is not None:
             self.rebroadcast_stop.set()
-            self.rebroadcast_thread.join(timeout=0.1)
+            if self.rebroadcast_thread is not None:
+                self.rebroadcast_thread.join(timeout=0.1)
         states, stop_evt, thread = start_server(port=port, scripts=[None] * 4)
         self.client.server_states = states
         self.rebroadcast_stop = stop_evt


### PR DESCRIPTION
## Summary
- ensure `_start_rebroadcast` checks for a valid stop event before calling `set`

## Testing
- `python -m py_compile viewer.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_684e69413d14832984c1047bc67feb6c