### PR TITLE
Enable disabling of scripted inputs

### DIFF
--- a/server.py
+++ b/server.py
@@ -90,12 +90,18 @@ def start_server(port: int = UDP_port,
         ]
 
         if scripts is None:
-            use_scripts = list(default_scripts)
+            use_scripts = [None] * 4
         else:
             use_scripts = []
             for i in range(4):
-                path = scripts[i] if i < len(scripts) else None
-                use_scripts.append(path or default_scripts[i])
+                if i < len(scripts):
+                    path = scripts[i]
+                    if path is None:
+                        use_scripts.append(None)
+                    else:
+                        use_scripts.append(path)
+                else:
+                    use_scripts.append(default_scripts[i])
 
         controller_threads: list[threading.Thread] = []
         for slot in controller_states:
@@ -192,6 +198,14 @@ if __name__ == "__main__":
         args.controller3_script,
         args.controller4_script,
     ]
+    if not any(scripts):
+        script_dir = os.path.dirname(__file__)
+        scripts = [
+            os.path.join(script_dir, "demo", "circle_loop.py"),
+            os.path.join(script_dir, "demo", "cross_loop.py"),
+            os.path.join(script_dir, "demo", "square_loop.py"),
+            os.path.join(script_dir, "demo", "triangle_loop.py"),
+        ]
 
     controller_states, stop_event, thread = start_server(
         port=args.port or UDP_port,


### PR DESCRIPTION
## Summary
- disable demo loops when `start_server` receives `scripts=None`
- load demo loops only when running `server.py` without script options

## Testing
- `python -m py_compile server.py viewer.py libraries/inputs.py libraries/masks.py libraries/net_config.py libraries/packet.py demo/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684e75b275148329b6c6aa4596b1a50e