### PR TITLE
Pass along connection type and battery in rebroadcast

### DIFF
--- a/libraries/masks.py
+++ b/libraries/masks.py
@@ -81,6 +81,7 @@ class ControllerState:
     gyroscope: Tuple[float, float, float] = (0.0, 0.0, 0.0)
 
     # Additional metadata from the originating server
+    connection_type: int = 2
     battery: int = 5
 
     # Rumble motor intensities and last update timestamps

--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -33,7 +33,16 @@ def send_port_info(addr, slot):
     if not state.connected:
         payload = b"\x00" * 12
     else:
-        payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, state.battery, 1)
+        payload = struct.pack(
+            '<4B6s2B',
+            slot,
+            2,
+            state.connection_type,
+            2,
+            mac_address,
+            state.battery,
+            1,
+        )
     packet = build_header(DSU_port_info, payload)
     sock.sendto(packet, addr)
     print(f"Sent port info for slot {slot} to {addr}")
@@ -135,6 +144,7 @@ def send_input(
     motion_timestamp=0,
     accelerometer=(0.0, 0.0, 0.0),
     gyroscope=(0.0, 0.0, 0.0),
+    connection_type=2,
     battery=5,
 ):
     if slot not in known_slots:
@@ -153,7 +163,16 @@ def send_input(
     touch2 = touchpad_input2 or touchpad_input()
 
     mac_address = slot_mac_addresses[slot]
-    payload = struct.pack('<4B6s2B', slot, 2, 2, 2, mac_address, battery, int(connected))
+    payload = struct.pack(
+        '<4B6s2B',
+        slot,
+        2,
+        connection_type,
+        2,
+        mac_address,
+        battery,
+        int(connected),
+    )
     payload += struct.pack('<I', counter)
     payload += struct.pack(
         '<BBBBBBBBBBBBBBBBBBBB',

--- a/server.py
+++ b/server.py
@@ -167,6 +167,8 @@ def start_server(port: int = UDP_port,
                             motion_timestamp=state.motion_timestamp,
                             accelerometer=state.accelerometer,
                             gyroscope=state.gyroscope,
+                            connection_type=state.connection_type,
+                            battery=state.battery,
                         )
                 for state in controller_states.values():
                     state.packet_num = (state.packet_num + 1) & 0xFFFFFFFF

--- a/viewer.py
+++ b/viewer.py
@@ -221,6 +221,7 @@ class DSUClient:
         cs.motion_timestamp = state["motion_ts"]
         cs.accelerometer = tuple(state["accel"])
         cs.gyroscope = tuple(state["gyro"])
+        cs.connection_type = state["connection_type"]
         cs.battery = state["battery"]
         net_cfg.slot_mac_addresses[slot] = bytes.fromhex(state["mac"].replace(":", ""))
 


### PR DESCRIPTION
## Summary
- include `connection_type` metadata in `ControllerState`
- forward connection type when viewer rebroadcasts
- send connection type and battery in port info and button data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685160cf55208329860b0b5ffc04bfd3