### PR TITLE
Fix rebroadcast port advertising

### DIFF
--- a/server.py
+++ b/server.py
@@ -150,8 +150,22 @@ def start_server(port: int = UDP_port,
                         del active_clients[addr]
                         print(f"Client {addr} timed out")
 
+                # Notify clients when a controller disconnects so the slot is
+                # properly marked as unused.
+                disconnected = []
+                for s, state in controller_states.items():
+                    if not state.connected and s in known_slots:
+                        for addr in active_clients:
+                            packet.send_port_disconnect(addr, s)
+                        disconnected.append(s)
+
+                for s in disconnected:
+                    known_slots.remove(s)
+
                 for addr in active_clients:
                     for s, state in controller_states.items():
+                        if not state.connected:
+                            continue
                         packet.send_input(
                             addr,
                             s,

--- a/server.py
+++ b/server.py
@@ -92,6 +92,18 @@ def start_server(port: int = UDP_port,
         connected_default = use_scripts[slot] is not None
         controller_states[slot] = ControllerState(connected=connected_default)
 
+    # Maintain per-server client tracking so rebroadcast servers don't share
+    # state with the original server or other rebroadcast instances.
+    active_clients = {}
+    known_slots = set()
+    logged_pad_requests = set()
+    last_button_states = {}
+
+    packet.active_clients = active_clients
+    packet.known_slots = known_slots
+    packet.logged_pad_requests = logged_pad_requests
+    packet.last_button_states = last_button_states
+
     stop_event = threading.Event()
 
     def _thread_main() -> None:


### PR DESCRIPTION
## Summary
- properly mark empty slots as disconnected
- pass desired scripts into the server thread

## Testing
- `python -m py_compile server.py viewer.py libraries/*.py demo/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685164540c588329844cc3bba2aaa3f6