### PR TITLE
Fix rebroadcast server slot advertising

### DIFF
--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -83,7 +83,8 @@ def handle_pad_data_request(addr, data):
     info = active_clients.setdefault(addr, {'last_seen': time.time(), 'slots': set()})
     info['last_seen'] = time.time()
     info['slots'].add(slot)
-    known_slots.add(slot)
+    if controller_states[slot].connected:
+        known_slots.add(slot)
     if slot not in logged_pad_requests:
         print(f"Registered input request from {addr} for slot {slot}")
         logged_pad_requests.add(slot)
@@ -148,6 +149,8 @@ def send_input(
     battery=5,
 ):
     if slot not in known_slots:
+        if not connected:
+            return
         known_slots.add(slot)
         for client in active_clients.keys():
             send_port_info(client, slot)

--- a/server.py
+++ b/server.py
@@ -63,7 +63,7 @@ def start_server(port: int = UDP_port,
     can update controller state or stop the server when done.
     """
 
-    controller_states = {slot: ControllerState() for slot in range(4)}
+    controller_states = {slot: ControllerState(connected=False) for slot in range(4)}
     stop_event = threading.Event()
 
     def _thread_main() -> None:
@@ -102,6 +102,15 @@ def start_server(port: int = UDP_port,
                         use_scripts.append(path)
                 else:
                     use_scripts.append(default_scripts[i])
+
+        known_slots.clear()
+        for slot in controller_states:
+            controller_states[slot].connected = False
+        for slot in range(4):
+            script_path = use_scripts[slot]
+            if script_path is not None:
+                controller_states[slot].connected = True
+                known_slots.add(slot)
 
         controller_threads: list[threading.Thread] = []
         for slot in controller_states:


### PR DESCRIPTION
## Summary
- don't announce slots unless they're connected
- clear known slots and flag active ones when launching a server

## Testing
- `pytest -q`
- `python -m py_compile server.py libraries/packet.py`


------
https://chatgpt.com/codex/tasks/task_e_68517fb000108329b6f679bf111946c3