### PR TITLE
Fix default simulated controller state

### DIFF
--- a/libraries/masks.py
+++ b/libraries/masks.py
@@ -55,7 +55,8 @@ def touchpad_input(active=False, touch_id=0, x=0, y=0):
 class ControllerState:
     """Current virtual controller state."""
 
-    connected: bool = True
+    # Match DS4Windows behaviour by defaulting to a disconnected state.
+    connected: bool = False
     packet_num: int = 0
 
     buttons1: int = button_mask_1()


### PR DESCRIPTION
## Summary
- match DS4Windows by defaulting `ControllerState.connected` to `False`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68518239b01883298ea1dbb03da9bf05