### PR TITLE
Fix viewer UI freeze when controllers disconnect

### DIFF
--- a/server.py
+++ b/server.py
@@ -156,7 +156,6 @@ def start_server(port: int = UDP_port,
                             for client in active_clients:
                                 packet.send_port_info(client, s)
                         else:
-                            known_slots.discard(s)
                             for client in active_clients:
                                 packet.send_port_disconnect(client, s)
                     for addr in active_clients:


### PR DESCRIPTION
## Summary
- keep slots in `known_slots` when controllers disconnect so that the server keeps sending DSU input packets with `connected=False`

## Testing
- `python -m py_compile server.py viewer.py libraries/*.py demo/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685191feceac8329a4f1e7c59952db9c