### PR TITLE
Fix DSUClient.stop thread shutdown

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -185,7 +185,8 @@ class DSUClient:
     def stop(self):
         self.running = False
         if self.thread is not None:
-            self.thread.join(timeout=0.1)
+            self.thread.join()
+            self.thread = None
 
     def _send(self, msg_type: int, payload: bytes = b""):
         self.sock.sendto(build_client_packet(msg_type, payload), self.addr)


### PR DESCRIPTION
## Summary
- wait for DSUClient thread without a timeout
- clear the thread reference when stopping

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852c83409188329b2aeeda4e7c98919