### PR TITLE
Ensure socket is closed on DSU client shutdown

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -167,7 +167,6 @@ class DSUClient:
     def restart(self, port: int):
         """Restart client communications on a new port."""
         self.stop()
-        self.sock.close()
         self.port = port
         self.addr = (self.server_ip, port)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -187,6 +186,9 @@ class DSUClient:
         if self.thread is not None:
             self.thread.join()
             self.thread = None
+        if self.sock is not None:
+            self.sock.close()
+            self.sock = None
 
     def _send(self, msg_type: int, payload: bytes = b""):
         self.sock.sendto(build_client_packet(msg_type, payload), self.addr)


### PR DESCRIPTION
## Summary
- close the UDP socket when DSUClient stops running
- rely on `stop()` for socket cleanup before restarting

## Testing
- `python -m py_compile viewer.py server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d5bc04188329be5e20126519f6a9