### PR TITLE
Add remote connection option to viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ python viewer.py
 ```
 
 By default it connects to `127.0.0.1` on port `26760`. The port can be changed
-from the **Options → Port** menu once the GUI is running. To connect to a
-different server IP, modify the final `main()` call in `viewer.py` or import the
-module and call `viewer.main('<server ip>')`.
+from the **Options → Port** menu once the GUI is running. Use **Options →
+Remote Connection** to connect to a different DSU server without restarting the
+program.
 
 The viewer also includes a **Rebroadcast** tool found under **Tools →
 Rebroadcast**. This feature launches a temporary DSU server that mirrors the

--- a/viewer.py
+++ b/viewer.py
@@ -165,11 +165,14 @@ class DSUClient:
         self.last_request = 0.0
         self.server_states = None
 
-    def restart(self, port: int):
-        """Restart client communications on a new port."""
+    def restart(self, port: int | None = None, server_ip: str | None = None):
+        """Restart client communications with an optional new port or server IP."""
         self.stop()
-        self.port = port
-        self.addr = (self.server_ip, port)
+        if port is not None:
+            self.port = port
+        if server_ip is not None:
+            self.server_ip = server_ip
+        self.addr = (self.server_ip, self.port)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.bind(("0.0.0.0", 0))
         self.sock.settimeout(0.1)
@@ -326,6 +329,7 @@ class ViewerUI:
         menu.add_cascade(label="Options", menu=self.options_menu)
         menu.add_cascade(label="Tools", menu=self.tools_menu)
         self.options_menu.add_command(label="Port", command=self._change_port)
+        self.options_menu.add_command(label="Remote Connection", command=self._change_remote)
         self.tools_menu.add_command(label="Rebroadcast", command=self._start_rebroadcast)
 
     def _start_rebroadcast(self):
@@ -355,6 +359,16 @@ class ViewerUI:
         )
         if port is not None:
             self.client.restart(port)
+
+    def _change_remote(self):
+        ip = simpledialog.askstring(
+            "Remote Connection",
+            "Enter DSU server IP:",
+            initialvalue=self.client.server_ip,
+            parent=self.root,
+        )
+        if ip:
+            self.client.restart(server_ip=ip)
 
     def update(self):
         for slot in range(4):


### PR DESCRIPTION
## Summary
- allow DSUClient to restart with a different IP or port
- add **Remote Connection** item to the viewer menu
- update README to document the new menu option

## Testing
- `python -m py_compile viewer.py server.py demo/*.py libraries/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852df3daf0c832981049f4d7f50b43b