### PR TITLE
Add idle controller slot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ are non‑standard but can be enabled by providing `--controller5-script`,
 `--controller6-script`, and so on. When extra scripts are supplied the server
 will create that many controller slots.
 
+Slots without a script start disconnected. To keep such a slot connected as an
+idle buffer, set `controller_states[slot].idle = True` after calling
+`start_server()`.
+
 ## Running the viewer
 
 The viewer connects to a DSU server and displays the state of up to four

--- a/libraries/masks.py
+++ b/libraries/masks.py
@@ -88,6 +88,10 @@ class ControllerState:
     connection_type: int = 2
     battery: int = 5
 
+    # Mark slot as idle. When ``True`` the server keeps the slot connected
+    # even if no inputs are active so it can be used as a buffer.
+    idle: bool = False
+
     # Rumble motor intensities and last update timestamps
     motors: Tuple[int, int] = (0, 0)
     motor_timestamps: Tuple[float, float] = (0.0, 0.0)
@@ -116,5 +120,9 @@ class ControllerState:
         return all([no_buttons, no_misc, sticks_centered, dpads_zero, triggers_zero, touches_inactive])
 
     def update_connection(self, dz: int = stick_deadzone) -> None:
-        """Synchronize ``connected`` with current input state using ``dz`` as the stick deadzone."""
-        self.connected = not self.is_idle(dz)
+        """Synchronize ``connected`` with current input state using ``dz`` as the stick deadzone.
+
+        When :attr:`idle` is ``True`` the slot remains connected regardless of
+        activity.  Otherwise connection is based on :meth:`is_idle`.
+        """
+        self.connected = self.idle or not self.is_idle(dz)


### PR DESCRIPTION
## Summary
- expose `idle` flag in `ControllerState`
- keep connection alive when slot is marked idle
- document how to use idle slots in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f1c97a808329a5943607246cddbb