### PR TITLE
Handle connection reset errors

### DIFF
--- a/server.py
+++ b/server.py
@@ -161,6 +161,9 @@ def start_server(port: int = UDP_port,
                                 packet.handle_motor_command(addr, data)
                 except BlockingIOError:
                     pass
+                except ConnectionResetError as exc:
+                    print(f"Client connection reset: {exc}")
+                    active_clients.clear()
                 except Exception as exc:
                     print(f"Error processing packet: {exc}")
 


### PR DESCRIPTION
## Summary
- stop log spam by catching `ConnectionResetError`

## Testing
- `python -m py_compile server.py libraries/*.py viewer.py demo/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6854069c9de883298f1a2dc1f233eccb