### PR TITLE
Improve disconnect logging

### DIFF
--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -48,7 +48,8 @@ def send_port_info(addr, slot):
         sock.sendto(packet, addr)
     except OSError as exc:
         print(f"Failed to send port info to {addr}: {exc}")
-        active_clients.pop(addr, None)
+        if active_clients.pop(addr, None) is not None:
+            print(f"Removed client {addr} after send failure")
     else:
         print(f"Sent port info for slot {slot} to {addr}")
 
@@ -61,7 +62,8 @@ def send_port_disconnect(addr, slot):
         sock.sendto(packet, addr)
     except OSError as exc:
         print(f"Failed to send port disconnect for slot {slot} to {addr}: {exc}")
-        active_clients.pop(addr, None)
+        if active_clients.pop(addr, None) is not None:
+            print(f"Removed client {addr} after send failure")
     else:
         print(f"Sent port disconnect for slot {slot} to {addr}")
 
@@ -75,7 +77,8 @@ def handle_version_request(addr):
         sock.sendto(packet, addr)
     except OSError as exc:
         print(f"Failed to send version response to {addr}: {exc}")
-        active_clients.pop(addr, None)
+        if active_clients.pop(addr, None) is not None:
+            print(f"Removed client {addr} after send failure")
     else:
         print(f"Sent version response to {addr}")
 
@@ -126,7 +129,8 @@ def handle_motor_request(addr, data):
         sock.sendto(packet, addr)
     except OSError as exc:
         print(f"Failed to send motor count to {addr} slot {slot}: {exc}")
-        active_clients.pop(addr, None)
+        if active_clients.pop(addr, None) is not None:
+            print(f"Removed client {addr} after send failure")
     else:
         print(f"Sent motor count {motor_count} to {addr} slot {slot}")
 
@@ -233,7 +237,8 @@ def send_input(
         sock.sendto(packet, addr)
     except OSError as exc:
         print(f"Failed to send input packet to {addr}: {exc}")
-        active_clients.pop(addr, None)
+        if active_clients.pop(addr, None) is not None:
+            print(f"Removed client {addr} after send failure")
         return
 
     prev_state = last_button_states.get(slot)

--- a/server.py
+++ b/server.py
@@ -163,6 +163,8 @@ def start_server(port: int = UDP_port,
                     pass
                 except ConnectionResetError as exc:
                     print(f"Client connection reset: {exc}")
+                    for client in list(active_clients):
+                        print(f"Removing client {client} due to connection reset")
                     active_clients.clear()
                 except Exception as exc:
                     print(f"Error processing packet: {exc}")


### PR DESCRIPTION
## Summary
- print removed clients when a connection reset occurs
- log when a client is removed after send failures

## Testing
- `python -m py_compile server.py viewer.py libraries/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685408dc26e4832988484514021d7ae7