### PR TITLE
Add idle loop script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ python server.py [--port PORT] [--server-id HEX] [--controller1-script PATH]
 ```
 
 If no options are provided the server listens on UDP port 26760 and uses the
-example controller scripts found in `demo/` to generate input. Custom scripts can
+example controller scripts found in `demo/` to generate input. These include
+`circle_loop.py`, `cross_loop.py`, `square_loop.py`, `triangle_loop.py`, and an
+`idle_loop.py` that keeps a slot connected without sending input. Custom scripts can
 be supplied per slot with the `--controllerN-script` arguments. Slots beyond 4
 are non‑standard but can be enabled by providing `--controller5-script`,
 `--controller6-script`, and so on. When extra scripts are supplied the server

--- a/demo/idle_loop.py
+++ b/demo/idle_loop.py
@@ -1,0 +1,9 @@
+import time
+from libraries.inputs import frame_delay
+
+
+def controller_loop(stop_event, controller_states, slot):
+    controller_states[slot].idle = True
+    while not stop_event.is_set():
+        time.sleep(frame_delay)
+


### PR DESCRIPTION
## Summary
- create `demo/idle_loop.py` that keeps a slot connected without producing input
- document example scripts in the README including new idle loop

## Testing
- `python -m py_compile demo/idle_loop.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68540f5c31748329a262b78000271d3f