### PR TITLE
Handle idle flag for new slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ example controller scripts found in `demo/` to generate input. These include
 be supplied per slot with the `--controllerN-script` arguments. Slots beyond 4
 are non‑standard but can be enabled by providing `--controller5-script`,
 `--controller6-script`, and so on. When extra scripts are supplied the server
-will create that many controller slots.
+will create that many controller slots. Use `None` to omit the controller
+thread for a slot while still allocating it.
 
 Slots without a script start disconnected. To keep such a slot connected as an
 idle buffer, set `controller_states[slot].idle = True` after calling
 `start_server()`. Accessing a non-existent slot will automatically create it so
 no extra setup is required.
+Passing `None` as the script path (any case) initializes a slot without running
+a controller loop.
 
 ## Running the viewer
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ will create that many controller slots.
 
 Slots without a script start disconnected. To keep such a slot connected as an
 idle buffer, set `controller_states[slot].idle = True` after calling
-`start_server()`.
+`start_server()`. Accessing a non-existent slot will automatically create it so
+no extra setup is required.
 
 ## Running the viewer
 

--- a/server.py
+++ b/server.py
@@ -140,11 +140,11 @@ def start_server(port: int = UDP_port,
                     use_scripts.append(default_scripts[i])
 
         known_slots.clear()
-        for slot in controller_states:
+        for slot in list(controller_states):
             controller_states[slot].connected = False
 
         controller_threads: list[threading.Thread] = []
-        for slot in controller_states:
+        for slot in list(controller_states):
             script_path = use_scripts[slot]
             if script_path is None:
                 continue
@@ -190,7 +190,7 @@ def start_server(port: int = UDP_port,
                         del active_clients[addr]
                         print(f"Client {addr} timed out")
 
-                for s, state in controller_states.items():
+                for s, state in list(controller_states.items()):
                     prev_connected = state.connected
                     state.update_connection(stick_deadzone)
                     if state.connected != prev_connected:
@@ -227,7 +227,7 @@ def start_server(port: int = UDP_port,
                             connection_type=state.connection_type,
                             battery=state.battery,
                         )
-                for state in controller_states.values():
+                for state in list(controller_states.values()):
                     state.packet_num = (state.packet_num + 1) & 0xFFFFFFFF
                     motors = list(state.motors)
                     timestamps = list(state.motor_timestamps)

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ import os
 
 from libraries.net_config import *
 import libraries.net_config as net_cfg
-from libraries.masks import *
+from libraries.masks import ControllerState, ControllerStateDict
 from libraries.inputs import load_controller_loop
 from libraries import packet
 
@@ -84,7 +84,7 @@ def start_server(port: int = UDP_port,
         print("Warning: more than four controller slots is non-standard but supported.")
     net_cfg.ensure_slot_count(slot_count)
 
-    controller_states = {slot: ControllerState(connected=False) for slot in range(slot_count)}
+    controller_states = ControllerStateDict({slot: ControllerState(connected=False) for slot in range(slot_count)})
     stop_event = threading.Event()
 
     def _thread_main() -> None:


### PR DESCRIPTION
## Summary
- create `ControllerStateDict` that auto-creates states on missing slot access
- use `ControllerStateDict` when starting the server
- document automatic slot creation in README

## Testing
- `python -m py_compile server.py viewer.py libraries/*.py demo/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685424cd659483299f825704ffd6c34f