### PR TITLE
Remove non-standard port info flag

### DIFF
--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -91,18 +91,17 @@ def build_header(msg_type: int, payload: bytes) -> bytes:
 def send_port_info(addr, slot):
     state = controller_states[slot]
     if state.connection_type == -1:
-        payload = b"\x00" * 12
+        payload = b"\x00" * 11
     else:
         mac_address = slot_mac_addresses[slot]
         payload = struct.pack(
-            '<4B6s2B',
+            '<4B6sB',
             slot,
             2,  # slot state - connected
             2,  # device model - full gyro
             state.connection_type,
             mac_address,
             state.battery,
-            1,
         )
     packet = build_header(DSU_port_info, payload)
     queue_packet(packet, addr, f"port info slot {slot}")
@@ -110,7 +109,7 @@ def send_port_info(addr, slot):
 
 def send_port_disconnect(addr, slot):
     """Send a port info packet indicating the slot is disconnected."""
-    payload = b"\x00" * 12
+    payload = b"\x00" * 11
     packet = build_header(DSU_port_info, payload)
     queue_packet(packet, addr, f"port disconnect slot {slot}")
 

--- a/tools/debug_packet/__init__.py
+++ b/tools/debug_packet/__init__.py
@@ -32,15 +32,16 @@ def parse_port_info(data: bytes):
     msg_type, = struct.unpack_from("<I", data, 16)
     if msg_type != DSU_port_info:
         return None
-    slot, state, model, connection_type, mac, battery, connected = struct.unpack_from(
-        "<4B6s2B", data, 20
+    slot, state, model, connection_type, mac, battery = struct.unpack_from(
+        "<4B6sB", data, 20
     )
     return {
         "slot": slot,
         "mac": ":".join(f"{b:02X}" for b in mac),
         "connection_type": connection_type,
         "battery": battery,
-        "connected": bool(connected),
+        "state": state,
+        "model": model,
     }
 
 
@@ -97,7 +98,7 @@ def describe_packet(packet: bytes) -> str:
             lines.append(f"Slot: {info['slot']} MAC: {info['mac']}")
             battery = BATTERY_STATES.get(info["battery"], f"0x{info['battery']:02X}")
             conn = CONNECTION_TYPES.get(info["connection_type"], str(info["connection_type"]))
-            lines.append(f"Connected: {info['connected']} Battery: {battery}")
+            lines.append(f"Battery: {battery}")
             lines.append(f"Connection: {conn}")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- clean up port info packet structure
- parse standard port info packets in debug parser

## Testing
- `python -m py_compile libraries/packet.py tools/debug_packet/__init__.py viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_68655d9fa7bc8329aa3e31b1aa36ec4d