### PR TITLE
Fix rumble info response header

### DIFF
--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -159,17 +159,17 @@ def handle_motor_request(addr, data):
     info = active_clients.setdefault(addr, {'last_seen': time.time(), 'slots': set()})
     info['last_seen'] = time.time()
     info['slots'].add(slot)
+    state = controller_states[slot]
     mac_address = slot_mac_addresses[slot]
-    motor_count = len(controller_states[slot].motors)
+    motor_count = len(state.motors)
     payload = struct.pack(
-        '<4B6s2B',
+        '<4B6sB',
         slot,
         2,  # slot state - connected
         2,  # device model - full gyro
-        2,  # connection type - assume USB
+        state.connection_type,
         mac_address,
-        5,
-        1,
+        state.battery,
     )
     payload += struct.pack('<B', motor_count)
     packet = build_header(DSU_motor_response, payload)


### PR DESCRIPTION
## Summary
- fix `handle_motor_request` payload to match port info format

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68656456a8588329842cd7edda936a3f