### PR TITLE
Add idle_1-4 demo script

### DIFF
--- a/demo/idle_1-4.py
+++ b/demo/idle_1-4.py
@@ -1,0 +1,23 @@
+import time
+import types
+
+from libraries.inputs import frame_delay
+from libraries import net_config as net_cfg
+
+
+def _noop_update(self, dz=net_cfg.stick_deadzone):
+    """Replacement ``update_connection`` method that preserves ``connected``."""
+    pass
+
+
+def controller_loop(stop_event, controller_states, slot):
+    """Mark the first four controller slots as always connected."""
+
+    for s in range(4):
+        state = controller_states[s]
+        state.connection_type = 2  # Default to Bluetooth
+        state.connected = True
+        state.update_connection = types.MethodType(_noop_update, state)
+
+    while not stop_event.is_set():
+        time.sleep(frame_delay)


### PR DESCRIPTION
## Summary
- add `demo/idle_1-4.py` for quickly bringing up four idle controller slots

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867b59f0f9083298a3260986ef5485a