### PR TITLE
Fix slot index handling

### DIFF
--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -89,8 +89,8 @@ def build_header(msg_type: int, payload: bytes) -> bytes:
 
 
 def send_port_info(addr, slot):
-    if slot >= net_cfg._MAC_LIMIT:
-        print("Warning: slots above 256 cannot be reported to the client")
+    if slot >= net_cfg.soft_slot_limit:
+        print("Warning: slots above 255 cannot be reported to the client")
         return
     state = controller_states[slot]
     if state.connection_type == -1:
@@ -112,8 +112,8 @@ def send_port_info(addr, slot):
 
 def send_port_disconnect(addr, slot):
     """Send a port info packet indicating the slot is disconnected."""
-    if slot >= net_cfg._MAC_LIMIT:
-        print("Warning: slots above 256 cannot be reported to the client")
+    if slot >= net_cfg.soft_slot_limit:
+        print("Warning: slots above 255 cannot be reported to the client")
         return
     payload = b"\x00" * 11
     packet = build_header(net_cfg.DSU_port_info, payload)
@@ -230,8 +230,8 @@ def send_input(
     connection_type=2,
     battery=5,
 ):
-    if slot >= net_cfg._MAC_LIMIT:
-        print("Warning: slots above 256 cannot be reported to the client")
+    if slot >= net_cfg.soft_slot_limit:
+        print("Warning: slots above 255 cannot be reported to the client")
         return
     if slot not in net_cfg.known_slots:
         if not connected:


### PR DESCRIPTION
## Summary
- start indexing controller slots from 1
- update MAC address generation to match the slot number
- keep slot 0 available but not initialized by default
- rename `_MAC_LIMIT` to `soft_slot_limit` and warn about extreme slot counts

## Testing
- `python -m py_compile libraries/net_config.py server.py libraries/packet.py libraries/inputs.py libraries/masks.py viewer.py demo/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6867efa38d248329bba48fc7adfe8f7b