### PR TITLE
Fix slot discovery logic

### DIFF
--- a/libraries/packet.py
+++ b/libraries/packet.py
@@ -115,7 +115,11 @@ def send_port_disconnect(addr, slot):
     if slot >= net_cfg.soft_slot_limit:
         print("Warning: slots above 255 cannot be reported to the client")
         return
-    payload = b"\x00" * 11
+    # Include the slot number in the payload so clients know which
+    # controller was disconnected. Older behaviour filled the entire
+    # payload with zeros which always reported slot 0, leading clients
+    # to believe an extra controller existed.
+    payload = struct.pack("<4B6sB", slot, 0, 0, 0, b"\x00" * 6, 0)
     packet = build_header(net_cfg.DSU_port_info, payload)
     queue_packet(packet, addr, f"port disconnect slot {slot}")
 

--- a/viewer.py
+++ b/viewer.py
@@ -288,7 +288,14 @@ class DSUClient:
                 elif msg_type == DSU_port_info:
                     info = parse_port_info(data)
                     if info:
-                        self.request_slots.add(info["slot"])
+                        slot = info["slot"]
+                        if info.get("state", 0) == 0:
+                            # Remove slots reported as disconnected to avoid
+                            # phantom controllers like an unused slot 0.
+                            self.request_slots.discard(slot)
+                            self.states.pop(slot, None)
+                        else:
+                            self.request_slots.add(slot)
             except socket.timeout:
                 pass
 


### PR DESCRIPTION
## Summary
- include slot number in disconnect packets
- filter out disconnected slots in the viewer client

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68680f72788c8329acc5fb90d1b7db7a