### PR TITLE
Fix default start slot

### DIFF
--- a/server.py
+++ b/server.py
@@ -100,7 +100,7 @@ def parse_arguments():
 def start_server(port: int = net_cfg.UDP_port,
                  server_id_value: int | None = None,
                  scripts: list | None = None,
-                 start_slot: int = 1):
+                 start_slot: int = 0):
     """Launch the DSUwU - Server in a background thread.
 
     Returns a tuple of ``(controller_states, stop_event, thread)`` so callers


### PR DESCRIPTION
## Summary
- align `start_server` default slot index with CLI behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686814eb9e488329975a32e951811ebc