### PR TITLE
Fix protocols relative imports

### DIFF
--- a/protocols/dsu.py
+++ b/protocols/dsu.py
@@ -21,8 +21,11 @@ from .dsu_constants import (
     DSU_motor_response,
     motor_command,
 )
-from ..libraries import net_config as net_cfg
-from ..libraries.masks import ControllerStateDict
+# Access the ``libraries`` package using absolute imports. ``protocols`` does
+# not sit inside a larger package hierarchy so moving up a level via a relative
+# import fails when this module is executed directly.
+from libraries import net_config as net_cfg
+from libraries.masks import ControllerStateDict
 
 
 class DSUProtocol:

--- a/protocols/dsu_packet.py
+++ b/protocols/dsu_packet.py
@@ -5,8 +5,11 @@ import queue
 import threading
 import socket
 
-from ..libraries import net_config as net_cfg
-from ..libraries.masks import button_mask_1, button_mask_2, touchpad_input
+# Import libraries from the project root. These modules are not part of a
+# package hierarchy above ``protocols`` so absolute imports are required when
+# this file is executed as part of the application.
+from libraries import net_config as net_cfg
+from libraries.masks import button_mask_1, button_mask_2, touchpad_input
 from .dsu_constants import (
     DSU_port_info,
     DSU_version_response,


### PR DESCRIPTION
## Summary
- use absolute imports for libraries module in `protocols`
- update DSU protocol packet imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python server.py --server-id 0xDEADBEEF --controller1-script demo/pygame_controller.py --controller2-script none --controller3-script none --controller4-script none` *(fails: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_686e8da8dc6083298a6930c5b9e6090d