### PR TITLE
Add full button support to pulse helpers

### DIFF
--- a/demo/Script.md
+++ b/demo/Script.md
@@ -11,6 +11,10 @@ It is recommended you import `time`, `libraries.inputs`, and `libraries.masks`, 
 
 **Push a button:** `pulse_button(frame, controller_states, slot, **button_kwargs)`, **frame** being how many 1/60ths of a second you want to press the button, **controller_states** being the server's controller dictionary, **slot** being the controller slot number you want to update, and **button_kwargs**. Defaults back to unpressed after finishing.
 Overwrites the entire controller state to match the exact buttons you describe. If you just say `circle=True` and nothing else, it will unpress everything else.
+Both `pulse_button` and `pulse_button_xor` accept button names from either mask
+(``share``/``l3``/``r3``/``options``/``up``/``right``/``down``/``left`` and
+``l2``/``r2``/``l1``/``r1``/``triangle``/``circle``/``cross``/``square``) as
+well as ``home``.
 
 **Toggle a button:** `pulse_button_xor(frame, controller_states, slot, *buttons)`, **frame** being how many 1/60ths of a second you want to press the button, **controller_states** being the server's controller dictionary, **slot** being the controller slot number you want to update, and ``*buttons`` representing one or more button names (e.g. ``"circle"``).
 Allows you to selectively write button states without modifying other buttons that share a "button mask". Useful if multiple functions or threads are sharing a slot. Keyword arguments are still accepted but ``False`` values are ignored.


### PR DESCRIPTION
## Summary
- expand `pulse_button` and `pulse_button_xor` to handle button mask 1 and `home`
- document supported buttons in demo Script guide

## Testing
- `python -m py_compile libraries/inputs.py`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6871d149812c83298a2f7fd82d61cc2c