### PR TITLE
Add text input controller script

### DIFF
--- a/demo/text_input_loop.py
+++ b/demo/text_input_loop.py
@@ -1,0 +1,29 @@
+import time
+
+from libraries.inputs import (
+    frame_delay,
+    pulse_button,
+    press_duration,
+    VALID_BUTTONS,
+)
+
+
+def controller_loop(stop_event, controller_states, slot):
+    """Prompt for button names and pulse them when entered."""
+
+    print("Text input controller: enter a button name or 'quit' to exit")
+    while not stop_event.is_set():
+        try:
+            entry = input("Button> ").strip().lower()
+        except EOFError:
+            break
+        if entry == "quit" or entry == "exit":
+            break
+        if entry not in VALID_BUTTONS:
+            print(f"Unknown button: {entry}")
+            continue
+        for i in range(press_duration + 1):
+            if stop_event.is_set():
+                break
+            pulse_button(i, controller_states, slot, **{entry: True})
+            time.sleep(frame_delay)


### PR DESCRIPTION
## Summary
- add a `text_input_loop` example script
- expose `VALID_BUTTONS` list in inputs library and include the touch button
- support `touch` in `pulse_button` and `pulse_button_xor`

## Testing
- `python -m py_compile demo/text_input_loop.py libraries/inputs.py`


------
https://chatgpt.com/codex/tasks/task_e_6872067d4ed483299f1f2db7e8e618df