### PR TITLE
Fix Windows spawn importing of controller scripts

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,7 @@
+try:
+    from libraries.inputs import register_input_scripts_from_env
+except Exception:
+    register_input_scripts_from_env = None
+
+if register_input_scripts_from_env is not None:
+    register_input_scripts_from_env()


### PR DESCRIPTION
## Summary
- ensure dynamically loaded controller scripts can be imported under Windows
- implement a small meta path loader that reloads scripts in spawned processes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872181dbda0832983cb311e5e8a304f