### PR TITLE
Open text input controller in its own window

### DIFF
--- a/demo/text_input_loop.py
+++ b/demo/text_input_loop.py
@@ -3,6 +3,7 @@ import threading
 from tkinter import (
     END,
     Entry,
+    Frame,
     Label,
     Scrollbar,
     StringVar,
@@ -23,17 +24,24 @@ def controller_loop(stop_event, controller_states, slot):
 
     root = Tk()
     root.title(f"Text input controller (slot {slot})")
-    root.minsize(320, 200)
+    root.minsize(400, 250)
 
     entry_var = StringVar()
     history: list[str] = []
     history_index = 0
 
-    log = Text(root, height=8, width=40, state="disabled", wrap="none")
-    scrollbar = Scrollbar(root, command=log.yview)
+    frame = Frame(root)
+    frame.pack(side="top", fill="both", expand=True, padx=10, pady=(5, 0))
+
+    log = Text(frame, height=8, state="disabled", wrap="none")
+    scrollbar = Scrollbar(frame, command=log.yview)
     log.configure(yscrollcommand=scrollbar.set)
-    log.pack(side="left", fill="both", expand=True, padx=10, pady=(5, 0))
-    scrollbar.pack(side="right", fill="y", pady=(5, 0))
+
+    log.grid(row=0, column=0, sticky="nsew")
+    scrollbar.grid(row=0, column=1, sticky="ns")
+
+    frame.columnconfigure(0, weight=1)
+    frame.rowconfigure(0, weight=1)
 
     def _append_log(msg: str) -> None:
         log.configure(state="normal")
@@ -65,9 +73,12 @@ def controller_loop(stop_event, controller_states, slot):
         threading.Thread(target=_pulse, daemon=True).start()
         return "break"
 
-    Label(root, text="Enter a button name or 'quit'").pack(padx=10, pady=5)
-    entry = Entry(root, textvariable=entry_var)
-    entry.pack(padx=10, pady=5, fill="x")
+    bottom = Frame(root)
+    bottom.pack(side="bottom", fill="x", padx=10, pady=5)
+
+    Label(bottom, text="Enter a button name or 'quit'").pack(anchor="w")
+    entry = Entry(bottom, textvariable=entry_var)
+    entry.pack(fill="x", pady=(2, 0))
     entry.bind("<Return>", _handle_entry)
 
     def _show_prev(event):

--- a/demo/text_input_loop.py
+++ b/demo/text_input_loop.py
@@ -1,4 +1,6 @@
 import time
+import threading
+from tkinter import Entry, Label, StringVar, Tk
 
 from libraries.inputs import (
     frame_delay,
@@ -9,21 +11,43 @@ from libraries.inputs import (
 
 
 def controller_loop(stop_event, controller_states, slot):
-    """Prompt for button names and pulse them when entered."""
+    """Open a small window for entering button names."""
 
-    print("Text input controller: enter a button name or 'quit' to exit")
-    while not stop_event.is_set():
-        try:
-            entry = input("Button> ").strip().lower()
-        except EOFError:
-            break
-        if entry == "quit" or entry == "exit":
-            break
-        if entry not in VALID_BUTTONS:
-            print(f"Unknown button: {entry}")
-            continue
-        for i in range(press_duration + 1):
-            if stop_event.is_set():
-                break
-            pulse_button(i, controller_states, slot, **{entry: True})
-            time.sleep(frame_delay)
+    root = Tk()
+    root.title(f"Text input controller (slot {slot})")
+
+    entry_var = StringVar()
+
+    def _handle_entry(event=None):
+        value = entry_var.get().strip().lower()
+        entry_var.set("")
+        if value in ("quit", "exit"):
+            root.destroy()
+            return
+        if value not in VALID_BUTTONS:
+            print(f"Unknown button: {value}")
+            return
+
+        def _pulse() -> None:
+            for i in range(press_duration + 1):
+                if stop_event.is_set():
+                    break
+                pulse_button(i, controller_states, slot, **{value: True})
+                time.sleep(frame_delay)
+
+        threading.Thread(target=_pulse, daemon=True).start()
+
+    Label(root, text="Enter a button name or 'quit'").pack(padx=10, pady=5)
+    entry = Entry(root, textvariable=entry_var)
+    entry.pack(padx=10, pady=5)
+    entry.bind("<Return>", _handle_entry)
+    entry.focus()
+
+    def _check_stop():
+        if stop_event.is_set():
+            root.destroy()
+        else:
+            root.after(100, _check_stop)
+
+    root.after(100, _check_stop)
+    root.mainloop()

--- a/demo/text_input_loop.py
+++ b/demo/text_input_loop.py
@@ -1,6 +1,14 @@
 import time
 import threading
-from tkinter import Entry, Label, StringVar, Tk
+from tkinter import (
+    END,
+    Entry,
+    Label,
+    Scrollbar,
+    StringVar,
+    Text,
+    Tk,
+)
 
 from libraries.inputs import (
     frame_delay,
@@ -15,18 +23,37 @@ def controller_loop(stop_event, controller_states, slot):
 
     root = Tk()
     root.title(f"Text input controller (slot {slot})")
+    root.minsize(320, 200)
 
     entry_var = StringVar()
+    history: list[str] = []
+    history_index = 0
+
+    log = Text(root, height=8, width=40, state="disabled", wrap="none")
+    scrollbar = Scrollbar(root, command=log.yview)
+    log.configure(yscrollcommand=scrollbar.set)
+    log.pack(side="left", fill="both", expand=True, padx=10, pady=(5, 0))
+    scrollbar.pack(side="right", fill="y", pady=(5, 0))
+
+    def _append_log(msg: str) -> None:
+        log.configure(state="normal")
+        log.insert(END, msg + "\n")
+        log.see(END)
+        log.configure(state="disabled")
 
     def _handle_entry(event=None):
+        nonlocal history_index
         value = entry_var.get().strip().lower()
         entry_var.set("")
+        history.append(value)
+        history_index = len(history)
+        _append_log(f"> {value}")
         if value in ("quit", "exit"):
             root.destroy()
-            return
+            return "break"
         if value not in VALID_BUTTONS:
-            print(f"Unknown button: {value}")
-            return
+            _append_log(f"Unknown button: {value}")
+            return "break"
 
         def _pulse() -> None:
             for i in range(press_duration + 1):
@@ -36,11 +63,38 @@ def controller_loop(stop_event, controller_states, slot):
                 time.sleep(frame_delay)
 
         threading.Thread(target=_pulse, daemon=True).start()
+        return "break"
 
     Label(root, text="Enter a button name or 'quit'").pack(padx=10, pady=5)
     entry = Entry(root, textvariable=entry_var)
-    entry.pack(padx=10, pady=5)
+    entry.pack(padx=10, pady=5, fill="x")
     entry.bind("<Return>", _handle_entry)
+
+    def _show_prev(event):
+        nonlocal history_index
+        if not history:
+            return "break"
+        if history_index > 0:
+            history_index -= 1
+        entry_var.set(history[history_index])
+        entry.icursor(END)
+        return "break"
+
+    def _show_next(event):
+        nonlocal history_index
+        if not history:
+            return "break"
+        if history_index < len(history):
+            history_index += 1
+        if history_index == len(history):
+            entry_var.set("")
+        else:
+            entry_var.set(history[history_index])
+        entry.icursor(END)
+        return "break"
+
+    entry.bind("<Up>", _show_prev)
+    entry.bind("<Down>", _show_next)
     entry.focus()
 
     def _check_stop():


### PR DESCRIPTION
## Summary
- replace console `input()` prompts with a simple Tkinter window
- spawn a small entry window so each text controller gets its own interface

## Testing
- `python -m py_compile demo/text_input_loop.py`
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68721dfad5bc83298dfc1acc7bab2eef